### PR TITLE
feat(masir): overhaul of core logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -291,12 +291,12 @@ pub fn listen_for_movements(hwnds: Option<PathBuf>) {
                             }
                         }
 
-                        if should_cache_eligibility {
-                            // ensure we cache eligibility to avoid syscalls and tests next time
-                            eligibility_cache.insert(cursor_pos_hwnd, true);
-                        }
-
                         if should_raise {
+                            if should_cache_eligibility {
+                                // ensure we cache eligibility to avoid syscalls and tests next time
+                                eligibility_cache.insert(cursor_pos_hwnd, true);
+                            }
+
                             // get the top-level window under the cursor
                             if let Ok(cursor_pos_top_level_hwnd) =
                                 get_ancestor(cursor_pos_hwnd, GA_ROOT)

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,9 +48,9 @@ enum MatchingStrategy {
 #[derive(Parser)]
 #[clap(author, about, version)]
 struct Opts {
-    /// Enable komorebi integration to avoid raising unmanaged windows
+    /// Disable automatic integrations with tiling window managers (e.g. komorebi)
     #[clap(long)]
-    komorebi: bool,
+    disable_integrations: bool,
     /// Path to a file with known focus-able HWNDs (e.g. komorebi.hwnd.json)
     #[clap(long)]
     hwnds: Option<PathBuf>,
@@ -60,20 +60,20 @@ fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
 
     let hwnds = match opts.hwnds {
+        None if opts.disable_integrations => None,
         None => {
+            let hwnds: PathBuf = dirs::data_local_dir()
+                .expect("there is no local data directory")
+                .join("komorebi")
+                .join("komorebi.hwnd.json");
+
             // TODO: We can add checks for other window managers here
-            let hwnds_option = if opts.komorebi {
-                Some(
-                    dirs::data_local_dir()
-                        .expect("there is no local data directory")
-                        .join("komorebi")
-                        .join("komorebi.hwnd.json"),
-                )
+
+            if hwnds.is_file() {
+                Some(hwnds)
             } else {
                 None
-            };
-
-            hwnds_option.filter(|hwnds| hwnds.is_file())
+            }
         }
         Some(hwnds) => {
             if hwnds.is_file() {


### PR DESCRIPTION
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's contribution guidelines.
-->

This pull request overhauls much of _masir_'s core logic to improve overall functionality. It can be summarized as follows:
1. _masir_ now additionally calls `GetAncestor()` to grab the top-level/root hwnd under the cursor, as opposed to directly using the hwnd from `WindowFromPoint()`, which might return a child window. This ensures correct behavior when raising windows to the foreground, which generally should be a top-level window.
2. _masir_ now tracks mouse press/release to avoid raising any windows while the mouse is being held down (i.e. when resizing a window or dragging and dropping files).
3. _masir_ now checks window styles to help determine eligibility when running without any twm integration. This means _masir_ is now completely standalone, whereas previously it had a soft dependency on komorebi and its hwnds file.
5. As a result of the above change, komorebi integration is no longer automatic; it has to be specified with the `--komorebi` argument when _masir_ is launched from the terminal.
7. _masir_ now checks **BOTH** the eligibility of the cursor hwnd as well as the foreground hwnd before raising any windows. This was done to improve compatibility with applications like Flow Launcher or PowerToys' PowerLauncher which previously would close as soon as they were launched if the cursor was outside their window area.
9. The call to `SetWindowPos` when raising windows was removed. It caused an issue where my auto-hidden taskbar would sometimes pop up when switching komorebi workspaces, and _masir_ seems to work fine without it from my testing.

TL;DR (the most important changes): 
1. _masir_ now requires the `--komorebi` argument to enable komorebi integration.
2. _masir_ now checks **BOTH** the eligibility of the cursor hwnd as well as the foreground hwnd.
3. Overall, _masir_ should work better now (hopefully!)